### PR TITLE
fix:Add padding to the mobile auth component

### DIFF
--- a/client/src/components/Auth/Auth.tsx
+++ b/client/src/components/Auth/Auth.tsx
@@ -9,7 +9,7 @@ interface Props {
 const Auth: React.FC<Props> = ({ setShowModal, isLoggin, setIsLoggin }) => {
   return (
     <div className="mx-auto flex min-h-screen w-full items-center justify-center bg-white text-white">
-      <section className="flex w-[30rem] flex-col space-y-10">
+      <section className="flex w-[30rem] flex-col space-y-10 px-5 md:px-0">
         <p className="text-center text-4xl font-medium text-teal-500">
           {isLoggin ? "Log In" : "Register"}
         </p>


### PR DESCRIPTION
This PR:
- Add Padding to the Login and Register Page in the Auth Component
- Made sure the padding only reflected on the mobile view and not other breakpoints
- The changes are shown in the images below
![image](https://user-images.githubusercontent.com/63306664/204018303-5aa0d8ab-0107-48ba-8e8f-353f6ab43dc3.png)
![image](https://user-images.githubusercontent.com/63306664/204018387-54d7af2d-a20b-42a1-b26b-934bd667255a.png)
